### PR TITLE
Add space after first paragraph of unstable spellbook text

### DIFF
--- a/src/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/UnstableSpellbook.java
+++ b/src/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/UnstableSpellbook.java
@@ -133,7 +133,7 @@ public class UnstableSpellbook extends Artifact {
             desc += "It fizzes and crackles as you move the pages, surging with unstable energy. ";
 
         desc += "It seems to contains a list of spells, but the order and position of them in the index is " +
-                "constantly shifting. if you read from this book, there's no telling what spell you might cast.";
+                "constantly shifting. if you read from this book, there's no telling what spell you might cast. ";
 
         if (isEquipped (Dungeon.hero)) {
             desc += "\n\n";


### PR DESCRIPTION
A minor tweak to add a space after the first paragraph of the Unstable Spellbook artifact. Prior to adding this, the text looks like: `might cast.The book's`