### PR TITLE
MeleeWeapon: Fix malevolent magic message

### DIFF
--- a/src/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/MeleeWeapon.java
+++ b/src/com/shatteredpixel/shatteredpixeldungeon/items/weapon/melee/MeleeWeapon.java
@@ -153,7 +153,7 @@ public class MeleeWeapon extends Weapon {
 		} else {
 			if (cursedKnown && cursed) {
 				info.append( p );
-				info.append( "You can feel a malevolent magic lurking within " + name +"." );
+				info.append( "You can feel a malevolent magic lurking within the " + name +"." );
 			}
 		}
 		


### PR DESCRIPTION
It's missing a 'the', which the other items already have.