### PR TITLE
Fixed grammar on 'welcome' text

### DIFF
--- a/core/src/main/resources/com/shatteredpixel/shatteredpixeldungeon/messages/scenes/scenes.properties
+++ b/core/src/main/resources/com/shatteredpixel/shatteredpixeldungeon/messages/scenes/scenes.properties
@@ -8,8 +8,8 @@ scenes.badgesscene.title=Your Badges
 
 scenes.changesscene.title=Recent Changes
 
-scenes.gamescene.welcome=Welcome to the level %d of Pixel Dungeon!
-scenes.gamescene.welcome_back=Welcome back to the level %d of Pixel Dungeon!
+scenes.gamescene.welcome=Welcome to level %d of Pixel Dungeon!
+scenes.gamescene.welcome_back=Welcome back to level %d of Pixel Dungeon!
 scenes.gamescene.chasm=Your steps echo across the dungeon.
 scenes.gamescene.water=You hear water splashing around you.
 scenes.gamescene.grass=The smell of vegetation is thick in the air.


### PR DESCRIPTION
Changed 'Welcome...' text from 'Welcome to *the* level 2 of Pixel Dungeon' to 'Welcome to level 2 of Pixel Dungeon'.