### PR TITLE
Remove unnecessary article

### DIFF
--- a/core/src/main/resources/com/shatteredpixel/shatteredpixeldungeon/messages/scenes/scenes.properties
+++ b/core/src/main/resources/com/shatteredpixel/shatteredpixeldungeon/messages/scenes/scenes.properties
@@ -16,8 +16,8 @@ scenes.changesscene.misc=Miscellaneous Changes
 scenes.changesscene.translation=Translation Improvements
 scenes.changesscene.previous=Previous Updates
 
-scenes.gamescene.welcome=Welcome to the level %d of Pixel Dungeon!
-scenes.gamescene.welcome_back=Welcome back to the level %d of Pixel Dungeon!
+scenes.gamescene.welcome=Welcome to level %d of Pixel Dungeon!
+scenes.gamescene.welcome_back=Welcome back to level %d of Pixel Dungeon!
 scenes.gamescene.chasm=Your steps echo across the dungeon.
 scenes.gamescene.water=You hear water splashing around you.
 scenes.gamescene.grass=The smell of vegetation is thick in the air.


### PR DESCRIPTION
The 'the' article in the sentence when you enter a new level of Pixel Dungeon has annoyed me since the very first time I played (Shattered) Pixel Dungeon, which was years ago. 

> Welcome to ~~the~~ level X of Pixel Dungeon!

I figured it would be fixed some day, but since that day has never come I thought: I'll fix it myself. Here you go!

Please discuss this language thing if you feel the article should be there: I'm not a native english speaker, so my change may not reflect the sentence's semantics as they were originally intended.