### PR TITLE
Fix bug related to progression items in heroes remains

### DIFF
--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/Bones.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/Bones.java
@@ -181,7 +181,7 @@ public class Bones {
 				} else if (item instanceof PotionOfStrength || item instanceof PotionOfMight ||
 						item instanceof ScrollOfUpgrade || item instanceof ScrollOfMagicalInfusion){
 
-					if (Random.IntRange(1, 3) >= depth){
+					if (Random.IntRange(1, 3) >= Dungeon.depth){
 						return new Gold(item.price());
 					}
 


### PR DESCRIPTION
This fixes a bug introduced with commit ef9a2a0d567b594dfa63551db823a512e8877eba.  Line 155 sets the Bones.depth static variable to 0, so the condition evaluated at line 184 will always evaluate to true.  It looks like you should be comparing against Dungeon.depth instead.