### PR TITLE
add google() repo to for findind the gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'


### PR DESCRIPTION
The android gradle plugin 3.0+ is only available via google() repo.
Thus we need to add the google() repo to the buildscript section as well.

Fixes: https://f-droid.org/wiki/page/com.shatteredpixel.shatteredpixeldungeon/lastbuild_242

   > Could not find com.android.tools.build:gradle:3.0.1.
     Searched in the following locations:
         https://jcenter.bintray.com/com/android/tools/build/gradle/3.0.1/gradle-3.0.1.pom
         https://jcenter.bintray.com/com/android/tools/build/gradle/3.0.1/gradle-3.0.1.jar
     Required by:
         project :