### PR TITLE
Fix hit chance computation for the Stone glyph

### DIFF
--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/armor/glyphs/Stone.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/armor/glyphs/Stone.java
@@ -39,7 +39,7 @@ public class Stone extends Armor.Glyph {
 		
 		float hitChance;
 		if (evasion >= accuracy){
-			hitChance = 1f - (1f - (accuracy/evasion))/2f;
+			hitChance = (accuracy/evasion)/2f;
 		} else {
 			hitChance = 1f - (evasion/accuracy)/2f;
 		}


### PR DESCRIPTION
The formula `1f - (1f - (accuracy/evasion))/2f` was clearly incorrect (in particular, it returns 1 (100% chance to hit) when accuracy == evasion). The cause seems to be a misplaced closing parenthesis. Moving that parenthesis gives `1f - (1f - (accuracy/evasion)/2f)`, which is correct, and can be simplified to `(accuracy/evasion)/2f`.

It seems like you don't accept pull requests, so feel free to close this and commit the change yourself if you'd like.