### PR TITLE
Replace C-style array declaration with Java-style

### DIFF
--- a/SPD-classes/src/main/java/com/watabou/glwrap/Matrix.java
+++ b/SPD-classes/src/main/java/com/watabou/glwrap/Matrix.java
@@ -100,7 +100,7 @@ public class Matrix {
 		m[13] += m[1] * x + m[5] * y;
 	}
 	
-	public static void multiply( float[] left, float right[], float[] result ) {
+	public static void multiply( float[] left, float[] right, float[] result ) {
 		final float ax1 = left[0];
 		final float ay1 = left[1];
 		final float az1 = left[2];


### PR DESCRIPTION
Replaces C-style array declaration of parameter 'right' with Java-style array declaration (`float[] right`)