### PR TITLE
Update WndGameInProgress.java

### DIFF
--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/windows/WndGameInProgress.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/windows/WndGameInProgress.java
@@ -154,11 +154,11 @@ public class WndGameInProgress extends Window {
 			}
 		};
 		
-		cont.setRect(0, HEIGHT - 20, WIDTH/2 -1, 20);
-		add(cont);
-		
-		erase.setRect(WIDTH/2 + 1, HEIGHT-20, WIDTH/2 - 1, 20);
+		erase.setRect(0, HEIGHT - 20, WIDTH/2 -1, 20);
 		add(erase);
+		
+		cont.setRect(WIDTH/2 + 1, HEIGHT-20, WIDTH/2 - 1, 20);
+		add(cont);
 		
 		resize(WIDTH, HEIGHT);
 	}


### PR DESCRIPTION
Switched Positions of 'Erase' and 'Continue'

Dear Developer, the continue Button should be on the right like every other 'ok'-button in every other app.
Erasing a game by mistake can be very frustrating.

Please consider accepting this PR :)