### PR TITLE
Refactor Badges class

### DIFF
--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/Char.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/Char.java
@@ -446,7 +446,7 @@ public abstract class Char extends Actor {
 
 					if (this instanceof WandOfLivingEarth.EarthGuardian
 							|| this instanceof MirrorImage || this instanceof PrismaticImage){
-						Badges.validateDeathFromFriendlyMagic();
+						Badges.Badge.DEATH_FROM_FRIENDLY_MAGIC.validate();
 					}
 					Dungeon.fail( getClass() );
 					GLog.n( Messages.capitalize(Messages.get(Char.class, "kill", name())) );

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/SacrificialFire.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/SacrificialFire.java
@@ -172,7 +172,7 @@ public class SacrificialFire extends Blob {
 				exp *= Random.IntRange( 2, 3 );
 			} else if (ch instanceof Hero) {
 				exp = 1_000_000; //always enough to activate the reward, if you can somehow get it
-				Badges.validateDeathFromSacrifice();
+				Badges.Badge.DEATH_FROM_SACRIFICE.validate();
 			}
 
 			if (exp > 0) {

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/ToxicGas.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/blobs/ToxicGas.java
@@ -70,7 +70,7 @@ public class ToxicGas extends Blob implements Hero.Doom {
 	@Override
 	public void onDeath() {
 		
-		Badges.validateDeathFromGas();
+		Badges.Badge.DEATH_FROM_GAS.validate();
 		
 		Dungeon.fail( getClass() );
 		GLog.n( Messages.get(this, "ondeath") );

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/AscensionChallenge.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/AscensionChallenge.java
@@ -251,7 +251,7 @@ public class AscensionChallenge extends Buff {
 				damageInc -= (int)damageInc;
 
 				if (target == Dungeon.hero && !target.isAlive()){
-					Badges.validateDeathFromFriendlyMagic();
+					Badges.Badge.DEATH_FROM_FRIENDLY_MAGIC.validate();
 					GLog.n(Messages.get(this, "on_kill"));
 					Dungeon.fail(Amulet.class);
 				}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/Bleeding.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/Bleeding.java
@@ -105,9 +105,9 @@ public class Bleeding extends Buff {
 				
 				if (target == Dungeon.hero && !target.isAlive()) {
 					if (source == Chasm.class){
-						Badges.validateDeathFromFalling();
+						Badges.Badge.DEATH_FROM_FALLING.validate();
 					} else if (source == Sacrificial.class){
-						Badges.validateDeathFromFriendlyMagic();
+						Badges.Badge.DEATH_FROM_FRIENDLY_MAGIC.validate();
 					}
 					Dungeon.fail( getClass() );
 					GLog.n( Messages.get(this, "ondeath") );

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/Burning.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/Burning.java
@@ -221,7 +221,7 @@ public class Burning extends Buff implements Hero.Doom {
 	@Override
 	public void onDeath() {
 		
-		Badges.validateDeathFromFire();
+		Badges.Badge.DEATH_FROM_FIRE.validate();
 		
 		Dungeon.fail( getClass() );
 		GLog.n( Messages.get(this, "ondeath") );

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/Corrosion.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/Corrosion.java
@@ -118,7 +118,7 @@ public class Corrosion extends Buff implements Hero.Doom {
 	@Override
 	public void onDeath() {
 		if (source == WandOfCorrosion.class){
-			Badges.validateDeathFromFriendlyMagic();
+			Badges.Badge.DEATH_FROM_FRIENDLY_MAGIC.validate();
 		}
 
 		Dungeon.fail( getClass() );

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/Hunger.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/Hunger.java
@@ -196,7 +196,7 @@ public class Hunger extends Buff implements Hero.Doom {
 	@Override
 	public void onDeath() {
 
-		Badges.validateDeathFromHunger();
+		Badges.Badge.DEATH_FROM_HUNGER.validate();
 
 		Dungeon.fail( getClass() );
 		GLog.n( Messages.get(this, "ondeath") );

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/Poison.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/Poison.java
@@ -115,7 +115,7 @@ public class Poison extends Buff implements Hero.Doom {
 
 	@Override
 	public void onDeath() {
-		Badges.validateDeathFromPoison();
+		Badges.Badge.DEATH_FROM_POISON.validate();
 		
 		Dungeon.fail( getClass() );
 		GLog.n( Messages.get(this, "ondeath") );

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/DM100.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/DM100.java
@@ -107,7 +107,7 @@ public class DM100 extends Mob implements Callback {
 					Camera.main.shake( 2, 0.3f );
 					
 					if (!enemy.isAlive()) {
-						Badges.validateDeathFromEnemyMagic();
+						Badges.Badge.DEATH_FROM_ENEMY_MAGIC.validate();
 						Dungeon.fail( getClass() );
 						GLog.n( Messages.get(this, "zap_kill") );
 					}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Eye.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Eye.java
@@ -190,7 +190,7 @@ public class Eye extends Mob {
 				}
 
 				if (!ch.isAlive() && ch == Dungeon.hero) {
-					Badges.validateDeathFromEnemyMagic();
+					Badges.Badge.DEATH_FROM_ENEMY_MAGIC.validate();
 					Dungeon.fail( getClass() );
 					GLog.n( Messages.get(this, "deathgaze_kill") );
 				}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Necromancer.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Necromancer.java
@@ -213,7 +213,7 @@ public class Necromancer extends Mob {
 				if (blocker.alignment != alignment){
 					blocker.damage( Random.NormalIntRange(2, 10), this );
 					if (blocker == Dungeon.hero && !blocker.isAlive()){
-						Badges.validateDeathFromEnemyMagic();
+						Badges.Badge.DEATH_FROM_ENEMY_MAGIC.validate();
 						Dungeon.fail(getClass());
 					}
 				}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Shaman.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Shaman.java
@@ -124,7 +124,7 @@ public abstract class Shaman extends Mob {
 			enemy.damage( dmg, new EarthenBolt() );
 			
 			if (!enemy.isAlive() && enemy == Dungeon.hero) {
-				Badges.validateDeathFromEnemyMagic();
+				Badges.Badge.DEATH_FROM_ENEMY_MAGIC.validate();
 				Dungeon.fail( getClass() );
 				GLog.n( Messages.get(this, "bolt_kill") );
 			}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/SpectralNecromancer.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/SpectralNecromancer.java
@@ -136,7 +136,7 @@ public class SpectralNecromancer extends Necromancer {
 				if (blocker.alignment != alignment){
 					blocker.damage( Random.NormalIntRange(2, 10), this );
 					if (blocker == Dungeon.hero && !blocker.isAlive()){
-						Badges.validateDeathFromEnemyMagic();
+						Badges.Badge.DEATH_FROM_ENEMY_MAGIC.validate();
 						Dungeon.fail(getClass());
 					}
 				}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Warlock.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Warlock.java
@@ -117,7 +117,7 @@ public class Warlock extends Mob implements Callback {
 			enemy.damage( dmg, new DarkBolt() );
 			
 			if (enemy == Dungeon.hero && !enemy.isAlive()) {
-				Badges.validateDeathFromEnemyMagic();
+				Badges.Badge.DEATH_FROM_ENEMY_MAGIC.validate();
 				Dungeon.fail( getClass() );
 				GLog.n( Messages.get(this, "bolt_kill") );
 			}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/YogDzewa.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/YogDzewa.java
@@ -240,7 +240,7 @@ public class YogDzewa extends Mob {
 							CellEmitter.center(pos).burst(PurpleParticle.BURST, Random.IntRange(1, 2));
 						}
 						if (!ch.isAlive() && ch == Dungeon.hero) {
-							Badges.validateDeathFromEnemyMagic();
+							Badges.Badge.DEATH_FROM_ENEMY_MAGIC.validate();
 							Dungeon.fail(getClass());
 							GLog.n(Messages.get(Char.class, "kill", name()));
 						}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/YogFist.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/YogFist.java
@@ -477,7 +477,7 @@ public abstract class YogFist extends Mob {
 				Buff.prolong( enemy, Blindness.class, Blindness.DURATION/2f );
 
 				if (!enemy.isAlive() && enemy == Dungeon.hero) {
-					Badges.validateDeathFromEnemyMagic();
+					Badges.Badge.DEATH_FROM_ENEMY_MAGIC.validate();
 					Dungeon.fail( getClass() );
 					GLog.n( Messages.get(Char.class, "kill", name()) );
 				}
@@ -546,7 +546,7 @@ public abstract class YogFist extends Mob {
 				}
 
 				if (!enemy.isAlive() && enemy == Dungeon.hero) {
-					Badges.validateDeathFromEnemyMagic();
+					Badges.Badge.DEATH_FROM_ENEMY_MAGIC.validate();
 					Dungeon.fail( getClass() );
 					GLog.n( Messages.get(Char.class, "kill", name()) );
 				}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/armor/glyphs/Viscosity.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/armor/glyphs/Viscosity.java
@@ -159,7 +159,7 @@ public class Viscosity extends Glyph {
 				target.damage( damageThisTick, this );
 				if (target == Dungeon.hero && !target.isAlive()) {
 
-					Badges.validateDeathFromFriendlyMagic();
+					Badges.Badge.DEATH_FROM_FRIENDLY_MAGIC.validate();
 
 					Dungeon.fail( getClass() );
 					GLog.n( Messages.get(this, "ondeath") );

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/ChaliceOfBlood.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/ChaliceOfBlood.java
@@ -122,7 +122,7 @@ public class ChaliceOfBlood extends Artifact {
 		hero.damage(damage, this);
 
 		if (!hero.isAlive()) {
-			Badges.validateDeathFromFriendlyMagic();
+			Badges.Badge.DEATH_FROM_FRIENDLY_MAGIC.validate();
 			Dungeon.fail( getClass() );
 			GLog.n( Messages.get(this, "ondeath") );
 		} else {

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/bombs/ArcaneBomb.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/bombs/ArcaneBomb.java
@@ -85,7 +85,7 @@ public class ArcaneBomb extends Bomb.MagicalBomb {
 			float multiplier = 1f - (.16667f*Dungeon.level.distance(cell, ch.pos));
 			ch.damage(Math.round(damage*multiplier), this);
 			if (ch == Dungeon.hero && !ch.isAlive()){
-				Badges.validateDeathFromFriendlyMagic();
+				Badges.Badge.DEATH_FROM_FRIENDLY_MAGIC.validate();
 				Dungeon.fail(Bomb.class);
 			}
 		}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/bombs/Bomb.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/bombs/Bomb.java
@@ -194,7 +194,7 @@ public class Bomb extends Item {
 				
 				if (ch == Dungeon.hero && !ch.isAlive()) {
 					if (this instanceof MagicalBomb){
-						Badges.validateDeathFromFriendlyMagic();
+						Badges.Badge.DEATH_FROM_FRIENDLY_MAGIC.validate();
 					}
 					GLog.n(Messages.get(this, "ondeath"));
 					Dungeon.fail(Bomb.class);

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/scrolls/exotic/ScrollOfPsionicBlast.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/scrolls/exotic/ScrollOfPsionicBlast.java
@@ -67,7 +67,7 @@ public class ScrollOfPsionicBlast extends ExoticScroll {
 			Dungeon.observe();
 			readAnimation();
 		} else {
-			Badges.validateDeathFromFriendlyMagic();
+			Badges.Badge.DEATH_FROM_FRIENDLY_MAGIC.validate();
 			Dungeon.fail( getClass() );
 			GLog.n( Messages.get(this, "ondeath") );
 		}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/wands/CursedWand.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/wands/CursedWand.java
@@ -225,11 +225,11 @@ public class CursedWand {
 						Sample.INSTANCE.play(Assets.Sounds.CURSED);
 						if (!toDamage.isAlive()) {
 							if (user == Dungeon.hero && origin != null) {
-								Badges.validateDeathFromFriendlyMagic();
+								Badges.Badge.DEATH_FROM_FRIENDLY_MAGIC.validate();
 								Dungeon.fail( origin.getClass() );
 								GLog.n( Messages.get( CursedWand.class, "ondeath", origin.name() ) );
 							} else {
-								Badges.validateDeathFromEnemyMagic();
+								Badges.Badge.DEATH_FROM_ENEMY_MAGIC.validate();
 								Dungeon.fail( toHeal.getClass() );
 							}
 						}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/wands/WandOfBlastWave.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/wands/WandOfBlastWave.java
@@ -166,7 +166,7 @@ public class WandOfBlastWave extends DamageWand {
 						Paralysis.prolong(ch, Paralysis.class, 1 + finalDist/2f);
 					} else if (ch == Dungeon.hero){
 						if (cause == WandOfBlastWave.class || cause == AquaBlast.class){
-							Badges.validateDeathFromFriendlyMagic();
+							Badges.Badge.DEATH_FROM_FRIENDLY_MAGIC.validate();
 						}
 						Dungeon.fail(cause);
 					}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/wands/WandOfLightning.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/wands/WandOfLightning.java
@@ -90,7 +90,7 @@ public class WandOfLightning extends DamageWand {
 		}
 
 		if (!curUser.isAlive()) {
-			Badges.validateDeathFromFriendlyMagic();
+			Badges.Badge.DEATH_FROM_FRIENDLY_MAGIC.validate();
 			Dungeon.fail( getClass() );
 			GLog.n(Messages.get(this, "ondeath"));
 		}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/wands/WandOfTransfusion.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/wands/WandOfTransfusion.java
@@ -132,7 +132,7 @@ public class WandOfTransfusion extends Wand {
 		curUser.damage(damage, this);
 
 		if (!curUser.isAlive()){
-			Badges.validateDeathFromFriendlyMagic();
+			Badges.Badge.DEATH_FROM_FRIENDLY_MAGIC.validate();
 			Dungeon.fail( getClass() );
 			GLog.n( Messages.get(this, "ondeath") );
 		}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/wands/WandOfWarding.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/wands/WandOfWarding.java
@@ -336,7 +336,7 @@ public class WandOfWarding extends Wand {
 			}
 
 			if (!enemy.isAlive() && enemy == Dungeon.hero) {
-				Badges.validateDeathFromFriendlyMagic();
+				Badges.Badge.DEATH_FROM_FRIENDLY_MAGIC.validate();
 				Dungeon.fail( getClass() );
 			}
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/missiles/ForceCube.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/missiles/ForceCube.java
@@ -73,7 +73,7 @@ public class ForceCube extends MissileWeapon {
 		for (Char target : targets){
 			curUser.shoot(target, this);
 			if (target == Dungeon.hero && !target.isAlive()){
-				Badges.validateDeathFromFriendlyMagic();
+				Badges.Badge.DEATH_FROM_FRIENDLY_MAGIC.validate();
 				Dungeon.fail(getClass());
 				GLog.n(Messages.get(this, "ondeath"));
 			}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/journal/Catalog.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/journal/Catalog.java
@@ -32,6 +32,8 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 
+import static java.util.Arrays.asList;
+
 public enum Catalog {
 	
 	WEAPONS,
@@ -43,7 +45,11 @@ public enum Catalog {
 	SCROLLS;
 	
 	private LinkedHashMap<Class<? extends Item>, Boolean> seen = new LinkedHashMap<>();
-	
+
+	public static List<Catalog> catalogs() {
+		return asList(Catalog.values());
+	}
+
 	public Collection<Class<? extends Item>> items(){
 		return seen.keySet();
 	}
@@ -180,7 +186,7 @@ public enum Catalog {
 		if (bundle.contains(CATALOG_ITEMS)) {
 			List<Class> seenClasses = new ArrayList<>();
 			if (bundle.contains(CATALOG_ITEMS)) {
-				seenClasses = Arrays.asList(bundle.getClassArray(CATALOG_ITEMS));
+				seenClasses = asList(bundle.getClassArray(CATALOG_ITEMS));
 			}
 			
 			for (Catalog cat : values()) {

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/features/Chasm.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/features/Chasm.java
@@ -124,7 +124,7 @@ public class Chasm implements Hero.Doom {
 
 	@Override
 	public void onDeath() {
-		Badges.validateDeathFromFalling();
+		Badges.Badge.DEATH_FROM_FALLING.validate();
 
 		Dungeon.fail( Chasm.class );
 		GLog.n( Messages.get(Chasm.class, "ondeath") );

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/SentryRoom.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/SentryRoom.java
@@ -278,7 +278,7 @@ public class SentryRoom extends SpecialRoom {
 		public void onZapComplete(){
 			Dungeon.hero.damage(Random.NormalIntRange(2+Dungeon.depth/2, 4+Dungeon.depth), new Eye.DeathGaze());
 			if (!Dungeon.hero.isAlive()){
-				Badges.validateDeathFromEnemyMagic();
+				Badges.Badge.DEATH_FROM_ENEMY_MAGIC.validate();
 				Dungeon.fail( getClass() );
 				GLog.n( Messages.capitalize(Messages.get(Char.class, "kill", name())) );
 			}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/traps/GrimTrap.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/traps/GrimTrap.java
@@ -100,7 +100,7 @@ public class GrimTrap extends Trap {
 									if (finalTarget == Dungeon.hero) {
 										Sample.INSTANCE.play(Assets.Sounds.CURSED);
 										if (!finalTarget.isAlive()) {
-											Badges.validateDeathFromGrimTrap();
+											Badges.Badge.DEATH_FROM_GRIM_TRAP.validate();
 											Dungeon.fail( GrimTrap.class );
 											GLog.n( Messages.get(GrimTrap.class, "ondeath") );
 										}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/utils/CollectionUtils.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/utils/CollectionUtils.java
@@ -1,0 +1,83 @@
+package com.shatteredpixel.shatteredpixeldungeon.utils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+public class CollectionUtils {
+
+    public static <T> List<T> filter(Iterable<T> collection, Predicate<T> condition) {
+        List<T> result = new ArrayList<>();
+        for (T element : collection) {
+            if (condition.test(element)) {
+                result.add(element);
+            }
+        }
+
+        return result;
+    }
+
+    public static <T> T getFirst(Iterable<T> collection, Predicate<T> condition) {
+        for (T element : collection) {
+            if (condition.test(element)) {
+                return element;
+            }
+        }
+
+        return null;
+    }
+
+    public static <T> boolean allMatch(Iterable<T> collection, Predicate<T> condition) {
+        for (T element : collection) {
+            if (!condition.test(element)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static <T> boolean anyMatch(Iterable<T> collection, Predicate<T> condition) {
+        for (T element : collection) {
+            if (condition.test(element)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public interface MapBuilder<K, V> {
+
+        MapBuilder<K, V> put(K key, V value);
+
+        Map<K, V> build();
+    }
+
+    static <K, V> MapBuilder<K, V> mapBuilder(final Map<K, V> map) {
+        return new MapBuilder<K, V>() {
+            @Override
+            public MapBuilder<K, V> put(K key, V value) {
+                map.put(key, value);
+                return this;
+            }
+
+            @Override
+            public Map<K, V> build() {
+                return Collections.unmodifiableMap(map);
+            }
+        };
+    }
+
+    public static <K, V> MapBuilder<K, V> mapBuilder() {
+        return mapBuilder(new HashMap<>());
+    }
+
+    public static <K, V> MapBuilder<K, V> linkedMapBuilder() {
+        return mapBuilder(new LinkedHashMap<>());
+    }
+}


### PR DESCRIPTION
**Right now this PR is mostly about asking would you be consider proposed change.** It is not ready to be merged as it should have tests showing no change before/after. It is more about starting discussion if you see it valuable and what would you expect to see added/modified before merging.

## Goal

This PR introduces a couple of changes aiming to:

* reduce duplication
* reduce bugs surface
* safeguard consistent behavior between badges handling

## Changes

### Generic `validate()` method

Instead of multiple methods validating specific badges, new methods are introduced:

* `validate(Badge badge)`
* `validateDeath(Badge badge)`

### Assign and access validation methods to badges enum constants

By default `validate(Badge)` is used to add badge. For death related enum constants this is set to `validateDeath(Badge)`.

### Generic `validateLevels(Map<Badge, Integer> levels, int value)` for leveled badges

Instead of copying same code between multiple validation methods for different badges and between conditional branches, single generic method is introduced. This way consistent approach is guaranteed.

### Introduce `CollectionUtils`

As for now it contains these basic utility functions:

```java
public static <T> List<T> filter(Iterable<T> collection, Predicate<T> condition)
public static <T> T getFirst(Iterable<T> collection, Predicate<T> condition)
public static <T> boolean allMatch(Iterable<T> collection, Predicate<T> condition)

// helpers for creation of immutable maps
public static <K, V> MapBuilder<K, V> mapBuilder()
public static <K, V> MapBuilder<K, V> linkedMapBuilder()
```

`filter`, `getFirst` and `allMatch` allow avoiding duplicated loops as in

```java
// instead of a loop copied in multiple places, allMatch hides it (internally it is still a loop)
boolean allUnlocked = allMatch(firstBossClassBadges.values(), Badges::isUnlocked);

// instead of for (Catalog cat : Catalog.values()) { if (allSeen(cat)) { ... }}
// filter returns a list of elements that match condition
filter(Catalog.catalogs(), Catalog::allSeen)
```

### Introduce `maybeDisplayBadge(Badge badge, Predicate<Badge> condition)`

Current code duplicates 6 lines for a conditional badge display. This helper method removes duplication so resulting code looks like this:

```java
maybeDisplayBadge(Badge.PIRANHAS, b -> Statistics.piranhasKilled >= 6);
```

## What now

All these changes remove 180 lines of code net.

I'd like to ask what do you think about this approach. If you think this may be a valuable change, I will 

* experiment with writing unit tests evidencing these changes did not break anything
* document and format changes a bit

But I want to ask you about your opinion do you actually want this change.

---

**Thanks for this fantastic game!**