### PR TITLE
F-Droid Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Shattered Pixel Dungeon currently compiles for Android, iOS, and Desktop platforms. You can find official releases of the game on:
 
 [![Get it on Google Play](https://shatteredpixel.com/assets/images/badges/gplay.png)](https://play.google.com/store/apps/details?id=com.shatteredpixel.shatteredpixeldungeon)
+[![Get it on F-Droid](https://github.com/00-Evan/shattered-pixel-dungeon/assets/60887273/3628dc2c-eed9-412c-b40e-27a863223197)](https://f-droid.org/en/packages/com.shatteredpixel.shatteredpixeldungeon)
 [![Download on the App Store](https://shatteredpixel.com/assets/images/badges/appstore.png)](https://apps.apple.com/app/shattered-pixel-dungeon/id1563121109)
 [![Steam](https://shatteredpixel.com/assets/images/badges/steam.png)](https://store.steampowered.com/app/1769170/Shattered_Pixel_Dungeon/)<br>
 [![GOG.com](https://shatteredpixel.com/assets/images/badges/gog.png)](https://www.gog.com/game/shattered_pixel_dungeon)


### PR DESCRIPTION
This game is a FOSS success story, thought it would be appropriate to show off the F-Droid link as well with a banner.
Using the other banners as a template, I created a banner for F-Droid as well and inserted it next to the "Get it on Google Play Store" banner.
[![Get it on F-Droid](https://github.com/00-Evan/shattered-pixel-dungeon/assets/60887273/3628dc2c-eed9-412c-b40e-27a863223197)](https://f-droid.org/en/packages/com.shatteredpixel.shatteredpixeldungeon)
I am fully aware, that the repo takes no Pull requests, but since this isn't code, I though I drop this here.

Thanks for the countless hours of fun.